### PR TITLE
[11.0] Improvement in product_dimension

### DIFF
--- a/product_dimension/models/product_template.py
+++ b/product_dimension/models/product_template.py
@@ -78,7 +78,14 @@ class ProductTemplatePropagateFieldsOnCreate(models.Model):
         )
 
         vals_to_propagate = {k: v for k, v in vals.items() if k in fields_to_propagate}
-        template.product_variant_ids.write(vals_to_propagate)
+
+        for variant in template.product_variant_ids:
+            # Only write values that are different from the variant's default value.
+            changed_values_to_propagate = {
+                k: v for k, v in vals_to_propagate.items()
+                if (v or variant[k]) and v != variant[k]
+            }
+            variant.write(changed_values_to_propagate)
 
         return template
 


### PR DESCRIPTION
When propagating values from the template to the variant, propagate only values that actually changed from the default value.

This prevents pollution in the mail thread of the variant.

https://isidor-prod.numigi.net/web#id=1785&view_type=form&model=project.task&menu_id=