### PR TITLE
Rename weight_uom_id to specific_weight_uom_id

### DIFF
--- a/product_dimension/__manifest__.py
+++ b/product_dimension/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     'name': 'Product Dimensions',
-    'version': '1.0.0',
+    'version': '1.1.0',
     'author': 'Savoir-faire Linux',
     'maintainer': 'Numigi',
     'website': 'https://bit.ly/numigi-com',

--- a/product_dimension/i18n/fr.po
+++ b/product_dimension/i18n/fr.po
@@ -125,8 +125,8 @@ msgid "Weight (kg)"
 msgstr "Masse (kg)"
 
 #. module: product_dimension
-#: model:ir.model.fields,field_description:product_dimension.field_product_product_weight_uom_id
-#: model:ir.model.fields,field_description:product_dimension.field_product_template_weight_uom_id
+#: model:ir.model.fields,field_description:product_dimension.field_product_product_specific_weight_uom_id
+#: model:ir.model.fields,field_description:product_dimension.field_product_template_specific_weight_uom_id
 msgid "Weight UoM"
 msgstr "UdM de la masse"
 

--- a/product_dimension/migrations/11.0.1.1.0/pre-migration.py
+++ b/product_dimension/migrations/11.0.1.1.0/pre-migration.py
@@ -1,0 +1,32 @@
+# © 2017 Savoir-faire Linux
+# © 2018 Numigi (tm) and all its contributors (https://bit.ly/numigiens)
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+
+from odoo import api, SUPERUSER_ID
+
+
+def migrate(cr, version):
+    """Delete views that depend on the field weight_uom_id.
+
+    Because weight_uom_id was renamed to specific_weight_uom_id,
+    we need to delete all views that depend on it.
+
+    Otherwise, the upgrade of the module fails.
+    """
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    views_to_update = [
+        'product_template_form_view_with_weight_in_uom',
+        'product_form_view_with_dimension_label',
+    ]
+
+    def delete_view_recursively(view):
+        for child in view.inherit_children_ids:
+            delete_view_recursively(child)
+        view.unlink()
+
+    for view_ref in views_to_update:
+        view = env.ref(
+            'product_dimension.{ref}'.format(ref=view_ref),
+            raise_if_not_found=False)
+        if view:
+            delete_view_recursively(view)

--- a/product_dimension/models/product_template.py
+++ b/product_dimension/models/product_template.py
@@ -16,7 +16,7 @@ class ProductTemplateWithWeightInKg(models.Model):
 
 
 class ProductTemplateWithWeightInUoM(models.Model):
-    """Add the fields weight_in_uom and weight_uom_id to products."""
+    """Add the fields weight_in_uom and specific_weight_uom_id to products."""
 
     _inherit = 'product.template'
 
@@ -25,9 +25,10 @@ class ProductTemplateWithWeightInUoM(models.Model):
         store=True,
     )
 
-    weight_uom_id = fields.Many2one(
-        related='product_variant_ids.weight_uom_id',
+    specific_weight_uom_id = fields.Many2one(
+        related='product_variant_ids.specific_weight_uom_id',
         store=True,
+        oldname='weight_uom_id',
     )
 
 
@@ -73,7 +74,7 @@ class ProductTemplatePropagateFieldsOnCreate(models.Model):
         template = super().create(vals)
 
         fields_to_propagate = (
-            'weight_in_uom', 'weight_uom_id',
+            'weight_in_uom', 'specific_weight_uom_id',
             'height', 'length', 'width', 'dimension_uom_id',
         )
 

--- a/product_dimension/tests/test_product_template.py
+++ b/product_dimension/tests/test_product_template.py
@@ -48,16 +48,16 @@ class TestProductTemplate(common.SavepointCase):
             'name': 'Test Product',
             'type': 'product',
             'weight_in_uom': self.weight_in_uom,
-            'weight_uom_id': self.gram.id,
+            'specific_weight_uom_id': self.gram.id,
         })
 
         self.template.refresh()
         self.assertEqual(self.template.weight_in_uom, self.weight_in_uom)
-        self.assertEqual(self.template.weight_uom_id, self.gram)
+        self.assertEqual(self.template.specific_weight_uom_id, self.gram)
         self.assertEqual(self.template.weight, self.weight)
 
         self.assertEqual(self.template.product_variant_ids.weight_in_uom, self.weight_in_uom)
-        self.assertEqual(self.template.product_variant_ids.weight_uom_id, self.gram)
+        self.assertEqual(self.template.product_variant_ids.specific_weight_uom_id, self.gram)
         self.assertEqual(self.template.product_variant_ids.weight, self.weight)
 
     def test_when_creating_product_template_then_weight_is_propagated_to_the_variant(self):
@@ -69,11 +69,11 @@ class TestProductTemplate(common.SavepointCase):
 
         self.template.refresh()
         self.assertEqual(self.template.weight_in_uom, 1)
-        self.assertEqual(self.template.weight_uom_id, self.kg)
+        self.assertEqual(self.template.specific_weight_uom_id, self.kg)
         self.assertEqual(self.template.weight, 1)
 
         self.assertEqual(self.template.product_variant_ids.weight_in_uom, 1)
-        self.assertEqual(self.template.product_variant_ids.weight_uom_id, self.kg)
+        self.assertEqual(self.template.product_variant_ids.specific_weight_uom_id, self.kg)
         self.assertEqual(self.template.product_variant_ids.weight, 1)
 
     def test_when_creating_product_template_then_volume_is_computed_on_the_variant(self):
@@ -96,7 +96,7 @@ class TestProductTemplate(common.SavepointCase):
             'name': 'Test Product',
             'type': 'product',
             'weight_in_uom': self.weight_in_uom,
-            'weight_uom_id': self.gram.id,
+            'specific_weight_uom_id': self.gram.id,
             'height': self.height,
             'length': self.length,
             'width': self.width,

--- a/product_dimension/tests/test_weight_in_uom.py
+++ b/product_dimension/tests/test_weight_in_uom.py
@@ -25,43 +25,43 @@ class TestProductWeightInUoM(common.SavepointCase):
         self.product.refresh()
         self.assertEqual(self.product.weight, 10)
         self.assertEqual(self.product.weight_in_uom, 10)
-        self.assertEqual(self.product.weight_uom_id, self.kg)
+        self.assertEqual(self.product.specific_weight_uom_id, self.kg)
 
-    def test_when_update_weight_if_has_weight_uom_then_weight_uom_id_is_not_changed(self):
+    def test_when_update_weight_if_has_weight_uom_then_specific_weight_uom_id_is_not_changed(self):
         """Test that when the weight is set, the current uom on the product is kept."""
-        self.product.weight_uom_id = self.gram
+        self.product.specific_weight_uom_id = self.gram
 
         self.product.weight = 10
 
         self.product.refresh()
         self.assertEqual(self.product.weight, 10)
         self.assertEqual(self.product.weight_in_uom, 10 * 1000)
-        self.assertEqual(self.product.weight_uom_id, self.gram)
+        self.assertEqual(self.product.specific_weight_uom_id, self.gram)
 
     def test_when_update_weight_in_uom_then_weight_is_updated(self):
         """Test that when the weight in uom is set, then the weight in kg is also updated."""
         self.product.write({
             'weight_in_uom': 10 * 1000,
-            'weight_uom_id': self.gram.id,
+            'specific_weight_uom_id': self.gram.id,
         })
 
         self.product.refresh()
         self.assertEqual(self.product.weight, 10)
         self.assertEqual(self.product.weight_in_uom, 10 * 1000)
-        self.assertEqual(self.product.weight_uom_id, self.gram)
+        self.assertEqual(self.product.specific_weight_uom_id, self.gram)
 
     def test_on_write_weight_in_uom_supersedes_weight(self):
         """Test that on write, if weight and weight_in_uom are given, weight_in_uom is kept."""
         self.product.write({
             'weight': 9,
             'weight_in_uom': 10 * 1000,
-            'weight_uom_id': self.gram.id,
+            'specific_weight_uom_id': self.gram.id,
         })
 
         self.product.refresh()
         self.assertEqual(self.product.weight, 10)
         self.assertEqual(self.product.weight_in_uom, 10 * 1000)
-        self.assertEqual(self.product.weight_uom_id, self.gram)
+        self.assertEqual(self.product.specific_weight_uom_id, self.gram)
 
     def test_on_create_if_weight_is_given_then_weight_in_uom_is_set(self):
         """Test that on create, if weight is given, then weight in uom is set."""
@@ -74,7 +74,7 @@ class TestProductWeightInUoM(common.SavepointCase):
         product.refresh()
         self.assertEqual(product.weight, 10)
         self.assertEqual(product.weight_in_uom, 10)
-        self.assertEqual(product.weight_uom_id, self.kg)
+        self.assertEqual(product.specific_weight_uom_id, self.kg)
 
     def test_on_create_if_weight_in_uom_is_given_then_weight_is_set(self):
         """Test that on create, if weight is given, then weight in uom is set."""
@@ -82,13 +82,13 @@ class TestProductWeightInUoM(common.SavepointCase):
             'name': 'New Product',
             'type': 'product',
             'weight_in_uom': 10 * 1000,
-            'weight_uom_id': self.gram.id,
+            'specific_weight_uom_id': self.gram.id,
         })
 
         product.refresh()
         self.assertEqual(product.weight, 10)
         self.assertEqual(product.weight_in_uom, 10 * 1000)
-        self.assertEqual(product.weight_uom_id, self.gram)
+        self.assertEqual(product.specific_weight_uom_id, self.gram)
 
     def test_on_create_weight_in_uom_supersedes_weight(self):
         """Test that on create, if weight and weight_in_uom are given, weight_in_uom is kept."""
@@ -97,10 +97,10 @@ class TestProductWeightInUoM(common.SavepointCase):
             'type': 'product',
             'weight': 9,
             'weight_in_uom': 10 * 1000,
-            'weight_uom_id': self.gram.id,
+            'specific_weight_uom_id': self.gram.id,
         })
 
         product.refresh()
         self.assertEqual(product.weight, 10)
         self.assertEqual(product.weight_in_uom, 10 * 1000)
-        self.assertEqual(product.weight_uom_id, self.gram)
+        self.assertEqual(product.specific_weight_uom_id, self.gram)

--- a/product_dimension/views/product.xml
+++ b/product_dimension/views/product.xml
@@ -26,9 +26,9 @@
                         domain="[('has_category_length', '=', True)]" options="{'no_create': True}"
                         attrs="{'required': ['|', '|', ('length', '!=', 0), ('width', '!=', 0), ('height', '!=', 0)]}"/>
 
-                    <field name="weight_in_uom" widget="float_with_uom" uom_field="weight_uom_id"/>
-                    <label for="weight_uom_id" class="oe_edit_only"/>
-                    <field name="weight_uom_id" class="oe_edit_only" nolabel="1"
+                    <field name="weight_in_uom" widget="float_with_uom" uom_field="specific_weight_uom_id"/>
+                    <label for="specific_weight_uom_id" class="oe_edit_only"/>
+                    <field name="specific_weight_uom_id" class="oe_edit_only" nolabel="1"
                         domain="[('has_category_weight', '=', True)]" options="{'no_create': True}"
                         attrs="{'required': [('weight_in_uom', '!=', 0)]}"/>
 

--- a/product_dimension/views/product_template.xml
+++ b/product_dimension/views/product_template.xml
@@ -64,9 +64,9 @@
         <field name="inherit_id" ref="stock.view_template_property_form"/>
         <field name="arch" type="xml">
             <label for="weight" position="before">
-                <field name="weight_in_uom" widget="float_with_uom" uom_field="weight_uom_id"/>
-                <label for="weight_uom_id" class="oe_edit_only"/>
-                <field name="weight_uom_id" class="oe_edit_only" nolabel="1"
+                <field name="weight_in_uom" widget="float_with_uom" uom_field="specific_weight_uom_id"/>
+                <label for="specific_weight_uom_id" class="oe_edit_only"/>
+                <field name="specific_weight_uom_id" class="oe_edit_only" nolabel="1"
                     domain="[('has_category_weight', '=', True)]" options="{'no_create': True}"
                     attrs="{'required': [('weight_in_uom', '!=', 0)]}"/>
             </label>


### PR DESCRIPTION
This prevents incompatibility with a field that has the same name in version 12.
The field in version 12 is computed and not stored, so this migration must be done before
migrating to version 12. Otherwise, the column will be deleted automatically by odoo.

https://isidor.numigi.net/web#id=5598&view_type=form&model=project.task&action=292&active_id=203&menu_id=200