### PR TITLE
Improve product_create_group

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,9 @@
+version: 2.0
+
+quay_io_login: &quay_io_login
+  name: Login to Quay.io register
+  command: docker login quay.io -u "${QUAY_USER}" -p "${QUAY_TOKEN}"
+
 jobs:
   tests:
     machine: true
@@ -5,8 +11,7 @@ jobs:
        - checkout
 
        - run:
-          name: Login to Quay.io
-          command: docker login quay.io -u "${QUAY_USER}" -p "${QUAY_TOKEN}"
+           <<: *quay_io_login
 
        - run:
           name: Build -- Init Database
@@ -25,29 +30,27 @@ jobs:
           command: |
             pip install codacy-coverage==1.3.10
             python-codacy-coverage -r .log/coverage.xml
-
        - store_test_results:
           path: .log
 
-  # job that find the next tag for the odoo-base and push the tag to github.
+  # job that find the next tag for the current branch/repo and push the tag to github.
   # it will trigger the publish of a new docker image.
   auto-tag:
     machine: true
     steps:
       - checkout
       - run:
-          name: Get next tag
-          command: |
-            echo 'export GITHUB_NEXT_TAG=$(curl -fL http://gcloud.functions.numigi.org/github_next_tag?github_user=${GITHUB_USER}\&github_password=${GITHUB_PASSWORD}\&repo=odoo-base\&filter=${CIRCLE_BRANCH/\.0/})' > $BASH_ENV
-            source $BASH_ENV
-            echo github next tag: ${GITHUB_NEXT_TAG}
+          <<: *quay_io_login
       - run:
-          name: Create tag
+          name: Get nws
           command: |
-            echo repo: odoo-base
-            echo branch: ${CIRCLE_BRANCH}
-            echo tag: ${GITHUB_NEXT_TAG}
-            echo github_create_tag $(curl -fL http://gcloud.functions.numigi.org/github_create_tag?github_user=${GITHUB_USER}\&github_password=${GITHUB_PASSWORD}\&repo=odoo-base\&branch=${CIRCLE_BRANCH}\&tag=${GITHUB_NEXT_TAG})
+            curl -L $NWS_BIN_LOCATION > ./nws
+            chmod +x ./nws
+      - run:
+          name: Set tag
+          command: |
+            ./nws circleci create-tag -t odoo-base
+            
 workflows:
   version: 2
   odoo:
@@ -56,7 +59,7 @@ workflows:
           context: quay.io
 
       - auto-tag:
-          context: github-robot
+          context: nws
           requires:
             - tests
           filters:

--- a/.docker_files/odoo.conf
+++ b/.docker_files/odoo.conf
@@ -1,5 +1,5 @@
 [options]
-addons_path = /mnt/extra-addons
+addons_path = /mnt/extra-addons,/mnt/third-party-addons
 csv_internal_sep = ,
 data_dir = /var/lib/odoo
 db_host = db

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,14 @@ USER root
 COPY .docker_files/test-requirements.txt .
 RUN pip3 install -r test-requirements.txt
 
+# Variable used for fetching private git repositories.
+ARG GIT_TOKEN
+
+ENV THIRD_PARTY_ADDONS /mnt/third-party-addons
+RUN mkdir -p "${THIRD_PARTY_ADDONS}" && chown -R odoo "${THIRD_PARTY_ADDONS}"
+COPY ./gitoo.yml /gitoo.yml
+RUN gitoo install-all --conf_file /gitoo.yml --destination "${THIRD_PARTY_ADDONS}"
+
 USER odoo
 
 COPY product_create_group /mnt/extra-addons/product_create_group

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        - GIT_TOKEN=${GIT_TOKEN}
     volumes:
       - odoo-web-data:/var/lib/odoo
       - ./.log:/var/log/odoo

--- a/gitoo.yml
+++ b/gitoo.yml
@@ -1,0 +1,4 @@
+- url: https://{{GIT_TOKEN}}@github.com/Numigi/odoo-base-addons
+  branch: "12.0"
+  includes:
+    - base_extended_security

--- a/product_create_group/README.rst
+++ b/product_create_group/README.rst
@@ -1,10 +1,23 @@
 Product Create Group
 ====================
-In vanilla Odoo, only the manager groups are allowed to create/edit products.
 
-This module adds a group to create/edit products and variants.
+This module adds a group to create / edit products and variants.
 
 .. image:: static/description/user_form.png
+
+Context
+-------
+In vanilla Odoo, only the manager groups are allowed to create or edit products.
+
+In some cases, you may want to allow other users to create or edit products without
+having to grant these full manager access over an application.
+
+Module Design
+-------------
+The module grants every internal user the access to create and edit products.
+
+Then, it adds `Extended Security Rules <https://github.com/Numigi/odoo-base-addons/tree/12.0/base_extended_security>`_
+to limit this access to the new group ``Manage Products and Variants``.
 
 Contributors
 ------------

--- a/product_create_group/__manifest__.py
+++ b/product_create_group/__manifest__.py
@@ -12,9 +12,11 @@
     'summary': 'Add a group to create/edit products and variants',
     'depends': [
         'product',
+        'base_extended_security',
     ],
     'data': [
         'security/res_groups.xml',
+        'security/extended_security_rule.xml',
         'security/ir.model.access.csv',
     ],
     'installable': True,

--- a/product_create_group/security/extended_security_rule.xml
+++ b/product_create_group/security/extended_security_rule.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0"?>
+<odoo>
+
+    <record id="product_product_rule" model="extended.security.rule">
+        <field name="group_ids" eval="[(4, ref('group_product_create'))]"/>
+        <field name="model_id" ref="product.model_product_product"/>
+        <field name="perm_write" eval="1"/>
+        <field name="perm_create" eval="1"/>
+    </record>
+
+    <record id="product_template_rule" model="extended.security.rule">
+        <field name="group_ids" eval="[(4, ref('group_product_create'))]"/>
+        <field name="model_id" ref="product.model_product_template"/>
+        <field name="perm_write" eval="1"/>
+        <field name="perm_create" eval="1"/>
+    </record>
+
+    <record id="product_price_history_rule" model="extended.security.rule">
+        <field name="group_ids" eval="[(4, ref('group_product_create'))]"/>
+        <field name="model_id" ref="product.model_product_price_history"/>
+        <field name="perm_write" eval="1"/>
+        <field name="perm_create" eval="1"/>
+    </record>
+
+    <record id="product_supplierinfo_rule" model="extended.security.rule">
+        <field name="group_ids" eval="[(4, ref('group_product_create'))]"/>
+        <field name="model_id" ref="product.model_product_supplierinfo"/>
+        <field name="perm_write" eval="1"/>
+        <field name="perm_create" eval="1"/>
+        <field name="perm_unlink" eval="1"/>
+    </record>
+
+    <record id="product_template_attribute_line_rule" model="extended.security.rule">
+        <field name="group_ids" eval="[(4, ref('group_product_create'))]"/>
+        <field name="model_id" ref="product.model_product_template_attribute_line"/>
+        <field name="perm_write" eval="1"/>
+        <field name="perm_create" eval="1"/>
+        <field name="perm_unlink" eval="1"/>
+    </record>
+
+    <record id="product_template_attribute_value_rule" model="extended.security.rule">
+        <field name="group_ids" eval="[(4, ref('group_product_create'))]"/>
+        <field name="model_id" ref="product.model_product_template_attribute_value"/>
+        <field name="perm_write" eval="1"/>
+        <field name="perm_create" eval="1"/>
+        <field name="perm_unlink" eval="1"/>
+    </record>
+
+    <record id="product_template_attribute_exclusion_rule" model="extended.security.rule">
+        <field name="group_ids" eval="[(4, ref('group_product_create'))]"/>
+        <field name="model_id" ref="product.model_product_template_attribute_value"/>
+        <field name="perm_write" eval="1"/>
+        <field name="perm_create" eval="1"/>
+        <field name="perm_unlink" eval="1"/>
+    </record>
+
+    <!-- By default, no-one can delete product variant and templates -->
+    <record id="product_product_unlink_rule" model="extended.security.rule">
+        <field name="model_id" ref="product.model_product_product"/>
+        <field name="perm_unlink" eval="1"/>
+    </record>
+
+    <record id="product_template_unlink_rule" model="extended.security.rule">
+        <field name="model_id" ref="product.model_product_template"/>
+        <field name="perm_unlink" eval="1"/>
+    </record>
+
+    <record id="product_price_history_unlink_rule" model="extended.security.rule">
+        <field name="model_id" ref="product.model_product_price_history"/>
+        <field name="perm_unlink" eval="1"/>
+    </record>
+
+</odoo>

--- a/product_create_group/security/ir.model.access.csv
+++ b/product_create_group/security/ir.model.access.csv
@@ -1,9 +1,9 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-access_ir_property,Manage Products and Variants: ir.property,base.model_ir_property,group_product_create,1,1,1,0
-access_product_product,Manage Products and Variants: product.product,product.model_product_product,group_product_create,1,1,1,0
-access_product_template,Manage Products and Variants: product.template,product.model_product_template,group_product_create,1,1,1,0
-access_product_price_history,Manage Products and Variants: product.price.history,product.model_product_price_history,group_product_create,1,1,1,0
-access_product_supplierinfo,Manage Products and Variants: product.supplierinfo,product.model_product_supplierinfo,group_product_create,1,1,1,1
-access_product_template_attribute_line,Manage Products and Variants: product.template.attribute.line,product.model_product_template_attribute_line,group_product_create,1,1,1,1
-access_product_template_attribute_value,Manage Products and Variants: product.template.attribute.value,product.model_product_template_attribute_value,group_product_create,1,1,1,1
-access_product_template_attribute_exclusion,Manage Products and Variants: product.template.attribute.exclusion,product.model_product_template_attribute_exclusion,group_product_create,1,1,1,1
+access_ir_property,Manage Products and Variants: ir.property,base.model_ir_property,base.group_user,1,1,1,1
+access_product_product,Manage Products and Variants: product.product,product.model_product_product,base.group_user,1,1,1,1
+access_product_template,Manage Products and Variants: product.template,product.model_product_template,base.group_user,1,1,1,1
+access_product_price_history,Manage Products and Variants: product.price.history,product.model_product_price_history,base.group_user,1,1,1,1
+access_product_supplierinfo,Manage Products and Variants: product.supplierinfo,product.model_product_supplierinfo,base.group_user,1,1,1,1
+access_product_template_attribute_line,Manage Products and Variants: product.template.attribute.line,product.model_product_template_attribute_line,base.group_user,1,1,1,1
+access_product_template_attribute_value,Manage Products and Variants: product.template.attribute.value,product.model_product_template_attribute_value,base.group_user,1,1,1,1
+access_product_template_attribute_exclusion,Manage Products and Variants: product.template.attribute.exclusion,product.model_product_template_attribute_exclusion,base.group_user,1,1,1,1


### PR DESCRIPTION
With this new approach, only members of the new group will be able to create or edit products.

This can however be customized per Odoo database. Extra groups such as Purchase / Managers can be added to
the extended security rules.

The main goal of this approach is to fix bugs in Odoo related to the access of products.
For example, in some edge cases, when creating an inventory adjustment, a stack trace is
raised if the user has not access to the product.

https://numigi.com/web#id=18759&action=298&model=project.task&view_type=form&menu_id=200